### PR TITLE
Add optional dict field to PolicyInputs

### DIFF
--- a/src/ai_safety_engine/models.py
+++ b/src/ai_safety_engine/models.py
@@ -13,6 +13,7 @@ class PolicyInput(BaseModel):
     input_videos: Optional[List[str]] = None
     input_audio: Optional[List[str]] = None
     input_files: Optional[List[str]] = None
+    extra_data: Optional[Dict[str, Any]] = None
 
 
 


### PR DESCRIPTION
Add an optional `extra_data` dictionary field to `PolicyInput` to allow passing arbitrary additional data for specific use cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-18c1e3d1-b52b-47db-94d7-59e55bb0f620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18c1e3d1-b52b-47db-94d7-59e55bb0f620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

